### PR TITLE
[Customers Product]: Change references from 'Users' to 'Customers' within documentation 👥

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ public partial class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsAppli
 }
 ```
 
-## Unique User Tracking
+## Customers
 
-Providing user information will allow Raygun to correlate error reports and RUM events with specific users.
-Assigning user information is performed by assigning a `RaygunUserInfo` object to your client instance. 
+Providing customer information will allow Raygun to correlate error reports and RUM events with specific customers.
+Assigning customer information is performed by assigning a `RaygunUserInfo` object to your client instance. 
 
 ``` csharp
 RaygunClient.Current.User = new RaygunUserInfo("_UNIQUE_ID_")


### PR DESCRIPTION
## [Customers Product]: Change references from 'User tracking' to 'Customers' within the documentation 👤

**NOTE: This is not to be merged until we have fully released the name change in the Raygun application. Changes to 'users' within the code need to be discussed and planned for.**

### Description 📝 
This PR is to updating the name convention for 'User tracking' to now be 'Customers' to reflect what's within the Raygun application.

**Updates**
👉 Update `README` documentation
👉 Update `CHANGELOG` document

### Test plan 🧪 
- Make sure documentation changes are reflected to be 'Customers' instead of 'Users' or 'User tracking'

### Checklist ✔️ 
- [x] Builds pass
- [x] Reviewed by another developer
- [x] Code is written to standards